### PR TITLE
fix: support typing overloaded functions

### DIFF
--- a/.lintignore
+++ b/.lintignore
@@ -2,3 +2,4 @@ coverage
 dist
 node_modules
 pnpm-lock.yaml
+tsconfig.vitest-temp.json

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![ci badge][]][ci]
 [![coverage badge][]][coverage]
 
-Stub behaviors of [vitest][] mock functions with a small, readable, and opinionated API. Inspired by [testdouble.js][] and [jest-when][].
+Stub behaviors of [Vitest][] mock functions with a small, readable API. Inspired by [testdouble.js][] and [jest-when][].
 
 ```shell
 npm install --save-dev vitest-when
@@ -22,18 +22,18 @@ npm install --save-dev vitest-when
 
 ## Usage
 
-The vitest-when package wraps [Vitest's mock functions][] in a focused, opinionated API that allows you to create [stubs][] - fake objects that have pre-configured responses to matching arguments. With vitest-when, your stubs are:
+Create [stubs][] - fake objects that have pre-configured responses to matching arguments - from [Vitest's mock functions][]. With vitest-when, your stubs are:
 
 - Easy to read
 - Hard to misconfigure, especially when using TypeScript
 
-Wrap your `vi.fn()` mock (or a function imported from a `vi.mock`'d module), in [`when`][when] and match on a set of arguments using [`calledWith`][called-with]. Then, configure a behavior:
+Wrap your `vi.fn()` mock - or a function imported from a `vi.mock`'d module - in [`when`][when], match on a set of arguments using [`calledWith`][called-with], and configure a behavior
 
-- Return a value: [`when(...).calledWith(...).thenReturn(...)`][then-return]
-- Resolve a `Promise`: [`when(...).calledWith(...).thenResolve(...)`][then-resolve]
-- Throw an error: [`when(...).calledWith(...).thenThrow(...)`][then-throw]
-- Reject a `Promise`: [`when(...).calledWith(...).thenReject(...)`][then-reject]
-- Trigger a function: [`when(...).calledWith(...).thenDo(...)`][then-do]
+- [`.thenReturn()`][then-return] - Return a value
+- [`.thenResolve()`][then-resolve] - Resolve a `Promise`
+- [`.thenThrow()`][then-throw] - Throw an error
+- [`.thenReject()`][then-reject] - Reject a `Promise`
+- [`.thenDo()`][then-do] - Trigger a function
 
 If the stub is called with arguments that match `calledWith`, the configured behavior will occur. If the arguments do not match, the stub will no-op and return `undefined`.
 
@@ -47,17 +47,22 @@ afterEach(() => {
 
 test('stubbing with vitest-when', () => {
   const stub = vi.fn();
-  when(stub).calledWith(1, 2, 3).thenReturn(4);
 
-  const result = stub(1, 2, 3);
+  when(stub).calledWith(1, 2, 3).thenReturn(4);
+  when(stub).calledWith(4, 5, 6).thenReturn(7);
+
+  const result123 = stub(1, 2, 3);
   expect(result).toBe(4);
 
-  const result = stub(4, 5, 6);
+  const result456 = stub(4, 5, 6);
+  expect(result).toBe(7);
+
+  const result789 = stub(7, 8, 9);
   expect(result).toBe(undefined);
 });
 ```
 
-You should call `vi.resetAllMocks()` in your suite's `afterEach` hook to remove the implementation added by `when`. You can also set the [`mockReset`](https://vitest.dev/config/#mockreset) config to `true` instead of using `afterEach`.
+You should call `vi.resetAllMocks()` in your suite's `afterEach` hook to remove the implementation added by `when`. You can also set Vitest's [`mockReset`](https://vitest.dev/config/#mockreset) config to `true` instead of using `afterEach`.
 
 [vitest's mock functions]: https://vitest.dev/api/mock.html
 [stubs]: https://en.wikipedia.org/wiki/Test_stub
@@ -75,7 +80,7 @@ Vitest's mock functions are powerful, but have an overly permissive API, inherit
 
 - Mock usage is spread across the [arrange and assert][] phases of your test, with "act" in between, making the test harder to read.
 - If you forget the `expect(...).toHaveBeenCalledWith(...)` step, the test will pass even if the mock is called incorrectly.
-- `expect(...).toHaveBeenCalledWith(...)` is not type-checked, as of vitest `0.31.0`.
+- `expect(...).toHaveBeenCalledWith(...)` is not type-checked, as of Vitest `0.31.0`.
 
 ```ts
 // arrange
@@ -140,7 +145,9 @@ describe('get the meaning of life', () => {
     expect(result).toEqual({ question: "What's 6 by 9?", answer: 42 });
   });
 });
+```
 
+```ts
 // meaning-of-life.ts
 import { calculateAnswer } from './deep-thought.ts';
 import { calculateQuestion } from './earth.ts';
@@ -156,12 +163,16 @@ export const createMeaning = async (): Promise<Meaning> => {
 
   return { question, answer };
 };
+```
 
+```ts
 // deep-thought.ts
 export const calculateAnswer = async (): Promise<number> => {
   throw new Error(`calculateAnswer() not implemented`);
 };
+```
 
+```ts
 // earth.ts
 export const calculateQuestion = async (answer: number): Promise<string> => {
   throw new Error(`calculateQuestion(${answer}) not implemented`);
@@ -175,6 +186,7 @@ export const calculateQuestion = async (answer: number): Promise<string> => {
 Configures a `vi.fn()` mock function to act as a vitest-when stub. Adds an implementation to the function that initially no-ops, and returns an API to configure behaviors for given arguments using [`.calledWith(...)`][called-with]
 
 ```ts
+import { vi } from 'vitest';
 import { when } from 'vitest-when';
 
 const spy = vi.fn();
@@ -194,7 +206,7 @@ const stub = when(spy).calledWith('hello').thenReturn('world');
 expect(spy('hello')).toEqual('world');
 ```
 
-When a call to a mock uses arguments that match those given to `calledWith`, a configured behavior will be triggered. All arguments must match, but you can use vitest's [asymmetric matchers][] to loosen the stubbing:
+When a call to a mock uses arguments that match those given to `calledWith`, a configured behavior will be triggered. All arguments must match, but you can use Vitest's [asymmetric matchers][] to loosen the stubbing:
 
 ```ts
 const spy = vi.fn();

--- a/example/meaning-of-life.test.ts
+++ b/example/meaning-of-life.test.ts
@@ -8,12 +8,12 @@ import * as subject from './meaning-of-life.ts';
 vi.mock('./deep-thought.ts');
 vi.mock('./earth.ts');
 
-describe('subject under test', () => {
+describe('get the meaning of life', () => {
   afterEach(() => {
     vi.resetAllMocks();
   });
 
-  it('should delegate work to dependency', async () => {
+  it('should get the answer and the question', async () => {
     when(deepThought.calculateAnswer).calledWith().thenResolve(42);
     when(earth.calculateQuestion).calledWith(42).thenResolve("What's 6 by 9?");
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vitest-when",
   "version": "0.1.1",
-  "description": "Stub behaviors of vitest mocks based on how they are called",
+  "description": "Stub behaviors of vitest mock functions with a small, readable, and opinionated API.",
   "type": "module",
   "exports": {
     ".": {
@@ -43,6 +43,7 @@
     "coverage": "vitest run --coverage",
     "check:format": "pnpm run _prettier --check",
     "check:lint": "pnpm run _eslint",
+    "check:types": "vitest typecheck --run",
     "format": "pnpm run _prettier --write && pnpm run _eslint --fix",
     "_eslint": "eslint --ignore-path .lintignore \"**/*.ts\"",
     "_prettier": "prettier --ignore-path .lintignore \"**/*.@(ts|json|yaml)\""

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vitest-when",
   "version": "0.1.1",
-  "description": "Stub behaviors of vitest mock functions with a small, readable, and opinionated API.",
+  "description": "Stub behaviors of Vitest mock functions with a small, readable API.",
   "type": "module",
   "exports": {
     ".": {
@@ -19,7 +19,7 @@
     "access": "public",
     "provenance": true
   },
-  "packageManager": "pnpm@8.5.0",
+  "packageManager": "pnpm@8.5.1",
   "author": "Michael Cousins <michael@cousins.io> (https://mike.cousins.io)",
   "license": "MIT",
   "repository": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Get function arguments and return value types.
+ *
+ * Support for overloaded functions, thanks to @Shakeskeyboarde
+ * https://github.com/microsoft/TypeScript/issues/14107#issuecomment-1146738780
+ */
+
+import type { SpyInstance } from 'vitest';
+
+/** Any function, for use in `extends` */
+export type AnyFunction = (...args: never[]) => unknown;
+
+/** Acceptable arguments for a function.*/
+export type AllParameters<TFunc extends AnyFunction> =
+  TFunc extends SpyInstance<infer TArgs, unknown>
+    ? TArgs
+    : Parameters<ToOverloads<TFunc>>;
+
+/** The return type of a function, given the actual arguments used.*/
+export type ReturnTypeFromArgs<
+  TFunc extends AnyFunction,
+  TArgs extends unknown[]
+> = TFunc extends SpyInstance<unknown[], infer TReturn>
+  ? TReturn
+  : ExtractReturn<ToOverloads<TFunc>, TArgs>;
+
+/** Given a functions and actual arguments used, extract the return type. */
+type ExtractReturn<
+  TFunc extends AnyFunction,
+  TArgs extends unknown[]
+> = TFunc extends (...args: infer TFuncArgs) => infer TFuncReturn
+  ? TArgs extends TFuncArgs
+    ? TFuncReturn
+    : never
+  : never;
+
+/** Transform an overloaded function into a union of functions. */
+type ToOverloads<TFunc extends AnyFunction> = Exclude<
+  OverloadUnion<(() => never) & TFunc>,
+  TFunc extends () => never ? never : () => never
+>;
+
+/** Recursively extract functions from an overload into a union. */
+type OverloadUnion<TFunc, TPartialOverload = unknown> = TFunc extends (
+  ...args: infer TArgs
+) => infer TReturn
+  ? TPartialOverload extends TFunc
+    ? never
+    :
+        | OverloadUnion<
+            TPartialOverload & TFunc,
+            TPartialOverload &
+              ((...args: TArgs) => TReturn) &
+              OverloadProps<TFunc>
+          >
+        | ((...args: TArgs) => TReturn)
+  : never;
+
+/** Properties attached to a function. */
+type OverloadProps<TFunc> = Pick<TFunc, keyof TFunc>;

--- a/src/vitest-when.ts
+++ b/src/vitest-when.ts
@@ -1,9 +1,18 @@
 import { configureStub } from './stubs.ts';
+import type { StubValue } from './behaviors.ts';
+import type {
+  AnyFunction,
+  AllParameters,
+  ReturnTypeFromArgs,
+} from './types.ts';
 
+export { ONCE, type StubValue } from './behaviors.ts';
 export * from './errors.ts';
 
-export interface StubWrapper<TArgs extends unknown[], TReturn> {
-  calledWith: (...args: TArgs) => Stub<TArgs, TReturn>;
+export interface StubWrapper<TFunc extends AnyFunction> {
+  calledWith<TArgs extends AllParameters<TFunc>>(
+    ...args: TArgs
+  ): Stub<TArgs, ReturnTypeFromArgs<TFunc, TArgs>>;
 }
 
 export interface Stub<TArgs extends unknown[], TReturn> {
@@ -11,90 +20,25 @@ export interface Stub<TArgs extends unknown[], TReturn> {
   thenResolve: (...values: StubValue<Awaited<TReturn>>[]) => void;
   thenThrow: (...errors: StubValue<unknown>[]) => void;
   thenReject: (...errors: StubValue<unknown>[]) => void;
-  thenDo: (...callbacks: StubValue<Callback<TArgs, TReturn>>[]) => void;
+  thenDo: (...callbacks: StubValue<(...args: TArgs) => TReturn>[]) => void;
 }
 
-export type Callback<TArgs extends unknown[], TReturn> = (
-  ...args: TArgs
-) => TReturn;
-
-export type StubValue<TValue> = TValue | typeof ONCE;
-
-export const ONCE = Symbol('ONCE');
-
-export const when = <TArgs extends unknown[], TReturn>(
-  spy: (...args: TArgs) => TReturn
-): StubWrapper<TArgs, TReturn> => {
-  const behaviors = configureStub<TArgs, TReturn>(spy);
+export const when = <TFunc extends AnyFunction>(
+  spy: TFunc
+): StubWrapper<TFunc> => {
+  const behaviorStack = configureStub(spy);
 
   return {
-    calledWith: (...args: TArgs) => ({
-      thenReturn: (...values: StubValue<TReturn>[]) => {
-        behaviors.add(
-          getBehaviorOptions(values).map(({ value, times }) => ({
-            args,
-            times,
-            returnValue: value,
-          }))
-        );
-      },
-      thenResolve: (...values: StubValue<Awaited<TReturn>>[]) => {
-        behaviors.add(
-          getBehaviorOptions(values).map(({ value, times }) => ({
-            args,
-            times,
-            returnValue: Promise.resolve(value) as TReturn,
-          }))
-        );
-      },
-      thenReject: (...errors: StubValue<unknown>[]) => {
-        behaviors.add(
-          getBehaviorOptions(errors).map(({ value, times }) => ({
-            args,
-            times,
-            returnValue: Promise.reject(value) as TReturn,
-          }))
-        );
-      },
-      thenThrow: (...errors: StubValue<unknown>[]) => {
-        behaviors.add(
-          getBehaviorOptions(errors).map(({ value, times }) => ({
-            args,
-            times,
-            throwError: value,
-          }))
-        );
-      },
-      thenDo: (...callbacks: StubValue<Callback<TArgs, TReturn>>[]) => {
-        behaviors.add(
-          getBehaviorOptions(callbacks).map(({ value, times }) => ({
-            args,
-            times,
-            doCallback: value,
-          }))
-        );
-      },
-    }),
+    calledWith: (...args) => {
+      const boundBehaviors = behaviorStack.bindArgs(args);
+
+      return {
+        thenReturn: (...values) => boundBehaviors.addReturn(values),
+        thenResolve: (...values) => boundBehaviors.addResolve(values),
+        thenThrow: (...errors) => boundBehaviors.addThrow(errors),
+        thenReject: (...errors) => boundBehaviors.addReject(errors),
+        thenDo: (...callbacks) => boundBehaviors.addDo(callbacks),
+      };
+    },
   };
-};
-
-interface BehaviorOptions<TValue> {
-  value: TValue;
-  times: number | undefined;
-}
-
-const getBehaviorOptions = <TValue>(
-  valuesAndOptions: StubValue<TValue>[]
-): BehaviorOptions<TValue>[] => {
-  const once = valuesAndOptions.includes(ONCE);
-  let values = valuesAndOptions.filter((value) => value !== ONCE) as TValue[];
-
-  if (values.length === 0) {
-    values = [undefined as TValue];
-  }
-
-  return values.map((value, i) => ({
-    value,
-    times: once || i < values.length - 1 ? 1 : undefined,
-  }));
 };

--- a/test/typing.test-d.ts
+++ b/test/typing.test-d.ts
@@ -1,0 +1,115 @@
+/* eslint-disable
+  @typescript-eslint/no-explicit-any,
+  @typescript-eslint/restrict-template-expressions,
+  func-style
+*/
+
+import { vi, describe, it, assertType } from 'vitest';
+import * as subject from '../src/vitest-when.ts';
+
+describe('vitest-when type signatures', () => {
+  it('should handle an anonymous mock', () => {
+    const spy = vi.fn();
+    const stub = subject.when(spy).calledWith(1, 2, 3);
+
+    assertType<subject.Stub<[number, number, number], any>>(stub);
+  });
+
+  it('should handle an untyped function', () => {
+    const stub = subject.when(untyped).calledWith(1);
+
+    stub.thenReturn('hello');
+
+    assertType<subject.Stub<[number], any>>(stub);
+  });
+
+  it('should handle a simple function', () => {
+    const stub = subject.when(simple).calledWith(1);
+
+    stub.thenReturn('hello');
+
+    assertType<subject.Stub<[1], string>>(stub);
+  });
+
+  it('should reject invalid usage of a simple function', () => {
+    // @ts-expect-error: args missing
+    subject.when(simple).calledWith();
+
+    // @ts-expect-error: args wrong type
+    subject.when(simple).calledWith('hello');
+
+    // @ts-expect-error: return wrong type
+    subject.when(simple).calledWith(1).thenReturn(42);
+  });
+
+  it('should handle an overloaded function using its last overload', () => {
+    const stub = subject.when(overloaded).calledWith(1);
+
+    stub.thenReturn('hello');
+
+    assertType<subject.Stub<[1], string>>(stub);
+  });
+
+  it('should handle an overloaded function using its first overload', () => {
+    const stub = subject.when(overloaded).calledWith();
+
+    stub.thenReturn(null);
+
+    assertType<subject.Stub<[], null>>(stub);
+  });
+
+  it('should handle an very overloaded function using its first overload', () => {
+    const stub = subject.when(veryOverloaded).calledWith();
+
+    stub.thenReturn(null);
+
+    assertType<subject.Stub<[], null>>(stub);
+  });
+
+  it('should handle an overloaded function using its last overload', () => {
+    const stub = subject.when(veryOverloaded).calledWith(1, 2, 3, 4);
+
+    stub.thenReturn(42);
+
+    assertType<subject.Stub<[1, 2, 3, 4], number>>(stub);
+  });
+
+  it('should reject invalid usage of a simple function', () => {
+    // @ts-expect-error: args missing
+    subject.when(simple).calledWith();
+
+    // @ts-expect-error: args wrong type
+    subject.when(simple).calledWith('hello');
+
+    // @ts-expect-error: return wrong type
+    subject.when(simple).calledWith(1).thenReturn(42);
+  });
+});
+
+function untyped(...args: any[]): any {
+  throw new Error(`untyped(...${args})`);
+}
+
+function simple(input: number): string {
+  throw new Error(`simple(${input})`);
+}
+
+function overloaded(): null;
+function overloaded(input: number): string;
+function overloaded(input?: number): string | null {
+  throw new Error(`overloaded(${input})`);
+}
+
+function veryOverloaded(): null;
+function veryOverloaded(i1: number): string;
+function veryOverloaded(i1: number, i2: number): boolean;
+function veryOverloaded(i1: number, i2: number, i3: number): null;
+function veryOverloaded(i1: number, i2: number, i3: number, i4: number): number;
+function veryOverloaded(
+  i1?: number,
+  i2?: number,
+  i3?: number,
+  i4?: number
+): string | boolean | number | null {
+  throw new Error(`veryOverloaded(${i1}, ${i2}, ${i3}, ${i4})`);
+}

--- a/test/vitest-when.test.ts
+++ b/test/vitest-when.test.ts
@@ -243,4 +243,15 @@ describe('vitest-when', () => {
 
     expect(spy('foo')).toEqual(1000);
   });
+
+  it('should deeply check object arguments', () => {
+    const spy = vi.fn();
+
+    subject
+      .when(spy)
+      .calledWith({ foo: { bar: { baz: 0 } } })
+      .thenReturn(100);
+
+    expect(spy({ foo: { bar: { baz: 0 } } })).toEqual(100);
+  });
 });


### PR DESCRIPTION
## Overview

TypeScript's built in `Parameters` and `ReturnType` utilities do not understand overloaded functions. This makes stubbing overloaded functions quite difficult with `vitest-when`, because `calledWith`, `thenReturn`, et. al. will get typed to accept the last overload rather than a union of all overloads.

This PR adds improves the typing for overloaded functions in two ways:

- `calledWith` will accept a union of all overloaded arguments
- `thenReturn`/`thenResolve` will accept the specific return type given the arguments used in `calledWith`

## Change log

- Add typing support for overloaded functions
- Add typing tests to make sure we support vanilla `vi.fn()`, untyped functions, non-overloaded functions, and overloaded functions
- Improve the README