### PR TITLE
fix: defer Promise.reject to avoid unhandled rejection error

### DIFF
--- a/src/behaviors.ts
+++ b/src/behaviors.ts
@@ -25,6 +25,7 @@ export interface BoundBehaviorStack<TReturn> {
 export interface BehaviorEntry<TArgs extends unknown[]> {
   args: TArgs
   returnValue?: unknown
+  rejectError?: unknown
   throwError?: unknown
   doCallback?: AnyFunction | undefined
   times?: number | undefined
@@ -86,7 +87,7 @@ export const createBehaviorStack = <
           ...getBehaviorOptions(values, options).map(({ value, times }) => ({
             args,
             times,
-            returnValue: Promise.reject(value),
+            rejectError: value,
           })),
         )
       },

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -32,6 +32,10 @@ export const configureStub = <TFunc extends AnyFunction>(
       throw behavior.throwError as Error
     }
 
+    if (behavior?.rejectError) {
+      return Promise.reject(behavior.rejectError)
+    }
+
     if (behavior?.doCallback) {
       return behavior.doCallback(...args)
     }

--- a/test/vitest-when.test.ts
+++ b/test/vitest-when.test.ts
@@ -256,4 +256,12 @@ describe('vitest-when', () => {
 
     expect(spy({ foo: { bar: { baz: 0 } } })).toEqual(100)
   })
+
+  it('should not trigger unhandled rejection warnings when rejection unused', () => {
+    const spy = vi.fn()
+    const error = new Error('uh uhh')
+    subject.when(spy).calledWith('/api/foo').thenReject(error)
+    // intentionally do not call the spy
+    expect(true).toBe(true)
+  })
 })


### PR DESCRIPTION
Thanks for the report @BeniRupp! The unhandled rejection problem seemed to be caused by the act of creating a rejection via `Promise.reject(error)`. The fix was pretty simple: instead of creating the rejection when the user calls `.thenReject(error)`, we wait to create the rejection until it the spy is actually called.

I appreciate the test case in your issue! I incorporated it into the suite

Fixes #7