### PR TITLE
feat: return mock from then methods

### DIFF
--- a/src/behaviors.ts
+++ b/src/behaviors.ts
@@ -3,8 +3,8 @@ import { equals } from '@vitest/expect'
 import type {
   AnyCallable,
   AnyFunction,
-  ExtractParameters,
-  ExtractReturnType,
+  ParametersOf,
+  ReturnTypeOf,
   WithMatchers,
 } from './types.ts'
 
@@ -14,17 +14,17 @@ export interface WhenOptions {
 
 export interface BehaviorStack<TFunc extends AnyCallable> {
   use: (
-    args: ExtractParameters<TFunc>,
-  ) => BehaviorEntry<ExtractParameters<TFunc>> | undefined
+    args: ParametersOf<TFunc>,
+  ) => BehaviorEntry<ParametersOf<TFunc>> | undefined
 
-  getAll: () => readonly BehaviorEntry<ExtractParameters<TFunc>>[]
+  getAll: () => readonly BehaviorEntry<ParametersOf<TFunc>>[]
 
-  getUnmatchedCalls: () => readonly ExtractParameters<TFunc>[]
+  getUnmatchedCalls: () => readonly ParametersOf<TFunc>[]
 
   bindArgs: (
-    args: WithMatchers<ExtractParameters<TFunc>>,
+    args: WithMatchers<ParametersOf<TFunc>>,
     options: WhenOptions,
-  ) => BoundBehaviorStack<ExtractReturnType<TFunc>>
+  ) => BoundBehaviorStack<ReturnTypeOf<TFunc>>
 }
 
 export interface BoundBehaviorStack<TReturn> {
@@ -65,8 +65,8 @@ export interface BehaviorOptions<TValue> {
 export const createBehaviorStack = <
   TFunc extends AnyCallable,
 >(): BehaviorStack<TFunc> => {
-  const behaviors: BehaviorEntry<ExtractParameters<TFunc>>[] = []
-  const unmatchedCalls: ExtractParameters<TFunc>[] = []
+  const behaviors: BehaviorEntry<ParametersOf<TFunc>>[] = []
+  const unmatchedCalls: ParametersOf<TFunc>[] = []
 
   return {
     getAll: () => behaviors,

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -3,9 +3,9 @@ import {
   plugins as prettyFormatPlugins,
 } from 'pretty-format'
 
-import { type Behavior, BehaviorType } from './behaviors'
-import { getBehaviorStack, validateSpy } from './stubs'
-import type { AnyCallable, MockInstance } from './types'
+import { type Behavior, BehaviorType } from './behaviors.ts'
+import { getBehaviorStack } from './stubs.ts'
+import type { AnyCallable, Mock } from './types.ts'
 
 export interface DebugResult {
   name: string
@@ -21,12 +21,11 @@ export interface Stubbing {
 }
 
 export const getDebug = <TFunc extends AnyCallable>(
-  spy: TFunc | MockInstance<TFunc>,
+  mock: Mock<TFunc>,
 ): DebugResult => {
-  const target = validateSpy<TFunc>(spy)
-  const name = target.getMockName()
-  const behaviors = getBehaviorStack(target)
-  const unmatchedCalls = behaviors?.getUnmatchedCalls() ?? target.mock.calls
+  const name = mock.getMockName()
+  const behaviors = getBehaviorStack(mock)
+  const unmatchedCalls = behaviors?.getUnmatchedCalls() ?? mock.mock.calls
   const stubbings =
     behaviors?.getAll().map((entry) => ({
       args: entry.args,

--- a/src/fallback-implementation.ts
+++ b/src/fallback-implementation.ts
@@ -1,17 +1,18 @@
-import type { AnyCallable, MockInstance } from './types.ts'
+import type { AnyCallable, AsFunction, Mock } from './types.ts'
 
 /** Get the fallback implementation of a mock if no matching stub is found. */
 export const getFallbackImplementation = <TFunc extends AnyCallable>(
-  mock: MockInstance<TFunc>,
-): TFunc | undefined => {
+  mock: Mock<TFunc>,
+): AsFunction<TFunc> | undefined => {
   return (
-    mock.getMockImplementation() ?? getTinyspyInternals(mock)?.getOriginal()
+    (mock.getMockImplementation() as AsFunction<TFunc> | undefined) ??
+    getTinyspyInternals(mock)?.getOriginal()
   )
 }
 
 /** Internal state from Tinyspy, where a mock's default implementation is stored. */
 interface TinyspyInternals<TFunc extends AnyCallable> {
-  getOriginal: () => TFunc | undefined
+  getOriginal: () => AsFunction<TFunc> | undefined
 }
 
 /**
@@ -24,7 +25,7 @@ interface TinyspyInternals<TFunc extends AnyCallable> {
  * which is stored on a Symbol key in the mock object.
  */
 const getTinyspyInternals = <TFunc extends AnyCallable>(
-  mock: MockInstance<TFunc>,
+  mock: Mock<TFunc>,
 ): TinyspyInternals<TFunc> | undefined => {
   const maybeTinyspy = mock as unknown as Record<PropertyKey, unknown>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 /** Common type definitions. */
 import type { AsymmetricMatcher } from '@vitest/expect'
+import type { MockedClass, MockedFunction } from 'vitest'
 
 /** Any function. */
 export type AnyFunction = (...args: never[]) => unknown
@@ -11,37 +12,34 @@ export type AnyConstructor = new (...args: never[]) => unknown
 export type AnyCallable = AnyFunction | AnyConstructor
 
 /** Extract parameters from either a function or constructor. */
-export type ExtractParameters<T> = T extends new (...args: infer P) => unknown
+export type ParametersOf<TFunc extends AnyCallable> = TFunc extends new (
+  ...args: infer P
+) => unknown
   ? P
-  : T extends (...args: infer P) => unknown
+  : TFunc extends (...args: infer P) => unknown
     ? P
     : never
 
 /** Extract return type from either a function or constructor */
-export type ExtractReturnType<T> = T extends new (...args: never[]) => infer R
+export type ReturnTypeOf<TFunc extends AnyCallable> = TFunc extends new (
+  ...args: never[]
+) => infer R
   ? R
-  : T extends (...args: never[]) => infer R
+  : TFunc extends (...args: never[]) => infer R
     ? R
     : never
+
+export type AsFunction<TFunc extends AnyCallable> = (
+  ...args: ParametersOf<TFunc>
+) => ReturnTypeOf<TFunc>
 
 /** Accept a value or an AsymmetricMatcher in an arguments array */
 export type WithMatchers<T extends unknown[]> = {
   [K in keyof T]: AsymmetricMatcher<unknown> | T[K]
 }
 
-/**
- * Minimally typed version of Vitest's `MockInstance`.
- *
- * Used to ensure backwards compatibility
- * with older versions of Vitest.
- */
-export interface MockInstance<TFunc extends AnyCallable = AnyCallable> {
-  getMockName(): string
-  getMockImplementation(): TFunc | undefined
-  mockImplementation: (impl: TFunc) => this
-  mock: MockContext<TFunc>
-}
-
-export interface MockContext<TFunc extends AnyCallable> {
-  calls: ExtractParameters<TFunc>[]
-}
+export type Mock<TFunc extends AnyCallable> = TFunc extends AnyFunction
+  ? MockedFunction<TFunc>
+  : TFunc extends AnyConstructor
+    ? MockedClass<TFunc>
+    : never

--- a/test/vitest-when.test.ts
+++ b/test/vitest-when.test.ts
@@ -27,9 +27,7 @@ describe('vitest-when', () => {
   })
 
   it('should return undefined by default', () => {
-    const spy = vi.fn()
-
-    subject.when(spy).calledWith(1, 2, 3).thenReturn(4)
+    const spy = subject.when(vi.fn()).calledWith(1, 2, 3).thenReturn(4)
 
     expect(spy()).toEqual(undefined)
     expect(spy(1)).toEqual(undefined)
@@ -39,26 +37,23 @@ describe('vitest-when', () => {
   })
 
   it('should return a value', () => {
-    const spy = vi.fn()
-
-    subject.when(spy).calledWith(1, 2, 3).thenReturn(4)
+    const spy = subject.when(vi.fn()).calledWith(1, 2, 3).thenReturn(4)
 
     expect(spy(1, 2, 3)).toEqual(4)
     expect(spy(1, 2, 3)).toEqual(4)
   })
 
   it('should return undefined if passed nothing', () => {
-    const spy = vi.fn()
-
-    subject.when(spy).calledWith(1, 2, 3).thenReturn()
+    const spy = subject.when(vi.fn()).calledWith(1, 2, 3).thenReturn()
 
     expect(spy(1, 2, 3)).toEqual(undefined)
   })
 
   it('should fall back to original mock implementation', () => {
-    const spy = vi.fn().mockReturnValue(100)
-
-    subject.when(spy).calledWith(1, 2, 3).thenReturn(4)
+    const spy = subject
+      .when(vi.fn().mockReturnValue(100))
+      .calledWith(1, 2, 3)
+      .thenReturn(4)
 
     expect(spy(1, 2, 3)).toEqual(4)
     expect(spy()).toEqual(100)
@@ -76,9 +71,10 @@ describe('vitest-when', () => {
   })
 
   it('should return a number of times', () => {
-    const spy = vi.fn()
-
-    subject.when(spy, { times: 2 }).calledWith(1, 2, 3).thenReturn(4)
+    const spy = subject
+      .when(vi.fn(), { times: 2 })
+      .calledWith(1, 2, 3)
+      .thenReturn(4)
 
     expect(spy(1, 2, 3)).toEqual(4)
     expect(spy(1, 2, 3)).toEqual(4)
@@ -86,18 +82,17 @@ describe('vitest-when', () => {
   })
 
   it('should be resettable', () => {
-    const spy = vi.fn()
-
-    subject.when(spy).calledWith(1, 2, 3).thenReturn(4)
+    const spy = subject.when(vi.fn()).calledWith(1, 2, 3).thenReturn(4)
     vi.resetAllMocks()
 
     expect(spy(1, 2, 3)).toEqual(undefined)
   })
 
   it('should throw an error', () => {
-    const spy = vi.fn()
-
-    subject.when(spy).calledWith(1, 2, 3).thenThrow(new Error('oh no'))
+    const spy = subject
+      .when(vi.fn())
+      .calledWith(1, 2, 3)
+      .thenThrow(new Error('oh no'))
 
     expect(() => {
       spy(1, 2, 3)
@@ -105,34 +100,29 @@ describe('vitest-when', () => {
   })
 
   it('should resolve a Promise', async () => {
-    const spy = vi.fn()
-
-    subject.when(spy).calledWith(1, 2, 3).thenResolve(4)
+    const spy = subject.when(vi.fn()).calledWith(1, 2, 3).thenResolve(4)
 
     await expect(spy(1, 2, 3)).resolves.toEqual(4)
   })
 
   it('should resolve undefined if passed nothing', async () => {
-    const spy = vi.fn()
-
-    subject.when(spy).calledWith(1, 2, 3).thenResolve()
+    const spy = subject.when(vi.fn()).calledWith(1, 2, 3).thenResolve()
 
     await expect(spy(1, 2, 3)).resolves.toEqual(undefined)
   })
 
   it('should reject a Promise', async () => {
-    const spy = vi.fn()
-
-    subject.when(spy).calledWith(1, 2, 3).thenReject(new Error('oh no'))
+    const spy = subject
+      .when(vi.fn())
+      .calledWith(1, 2, 3)
+      .thenReject(new Error('oh no'))
 
     await expect(spy(1, 2, 3)).rejects.toThrow('oh no')
   })
 
   it('should do a callback', () => {
-    const spy = vi.fn()
     const callback = vi.fn(() => 4)
-
-    subject.when(spy).calledWith(1, 2, 3).thenDo(callback)
+    const spy = subject.when(vi.fn()).calledWith(1, 2, 3).thenDo(callback)
 
     expect(spy(1, 2, 3)).toEqual(4)
     expect(callback).toHaveBeenCalledWith(1, 2, 3)
@@ -140,9 +130,7 @@ describe('vitest-when', () => {
   })
 
   it('should return multiple values', () => {
-    const spy = vi.fn()
-
-    subject.when(spy).calledWith(1, 2, 3).thenReturn(4, 5, 6)
+    const spy = subject.when(vi.fn()).calledWith(1, 2, 3).thenReturn(4, 5, 6)
 
     expect(spy(1, 2, 3)).toEqual(4)
     expect(spy(1, 2, 3)).toEqual(5)
@@ -151,9 +139,7 @@ describe('vitest-when', () => {
   })
 
   it('should resolve multiple values', async () => {
-    const spy = vi.fn()
-
-    subject.when(spy).calledWith(1, 2, 3).thenResolve(4, 5, 6)
+    const spy = subject.when(vi.fn()).calledWith(1, 2, 3).thenResolve(4, 5, 6)
 
     await expect(spy(1, 2, 3)).resolves.toEqual(4)
     await expect(spy(1, 2, 3)).resolves.toEqual(5)
@@ -162,10 +148,8 @@ describe('vitest-when', () => {
   })
 
   it('should reject multiple errors', async () => {
-    const spy = vi.fn()
-
-    subject
-      .when(spy)
+    const spy = subject
+      .when(vi.fn())
       .calledWith(1, 2, 3)
       .thenReject(new Error('4'), new Error('5'), new Error('6'))
 
@@ -176,10 +160,8 @@ describe('vitest-when', () => {
   })
 
   it('should reject a number of times', async () => {
-    const spy = vi.fn()
-
-    subject
-      .when(spy, { times: 2 })
+    const spy = subject
+      .when(vi.fn(), { times: 2 })
       .calledWith(1, 2, 3)
       .thenReject(new Error('4'))
 
@@ -189,32 +171,31 @@ describe('vitest-when', () => {
   })
 
   it('should throw multiple errors', () => {
-    const spy = vi.fn()
-
-    subject
-      .when(spy)
+    const spy = subject
+      .when(vi.fn())
       .calledWith(1, 2, 3)
       .thenThrow(new Error('4'), new Error('5'), new Error('6'))
 
     expect(() => {
       spy(1, 2, 3)
     }).toThrow('4')
+
     expect(() => {
       spy(1, 2, 3)
     }).toThrow('5')
+
     expect(() => {
       spy(1, 2, 3)
     }).toThrow('6')
+
     expect(() => {
       spy(1, 2, 3)
     }).toThrow('6')
   })
 
   it('should call multiple callbacks', () => {
-    const spy = vi.fn()
-
-    subject
-      .when(spy)
+    const spy = subject
+      .when(vi.fn())
       .calledWith(1, 2, 3)
       .thenDo(
         () => 4,
@@ -229,9 +210,7 @@ describe('vitest-when', () => {
   })
 
   it('should allow multiple different stubs', () => {
-    const spy = vi.fn()
-
-    subject.when(spy).calledWith(1, 2, 3).thenReturn(4)
+    const spy = subject.when(vi.fn()).calledWith(1, 2, 3).thenReturn(4)
     subject.when(spy).calledWith(4, 5, 6).thenReturn(7)
 
     expect(spy(1, 2, 3)).toEqual(4)
@@ -239,19 +218,15 @@ describe('vitest-when', () => {
   })
 
   it('should use the latest stub', () => {
-    const spy = vi.fn()
-
-    subject.when(spy).calledWith(1, 2, 3).thenReturn(4)
+    const spy = subject.when(vi.fn()).calledWith(1, 2, 3).thenReturn(4)
     subject.when(spy).calledWith(1, 2, 3).thenReturn(1000)
 
     expect(spy(1, 2, 3)).toEqual(1000)
   })
 
   it('should respect asymmetric matchers', () => {
-    const spy = vi.fn()
-
-    subject
-      .when(spy)
+    const spy = subject
+      .when(vi.fn())
       .calledWith(expect.stringContaining('foo'))
       .thenReturn(1000)
 
@@ -259,18 +234,17 @@ describe('vitest-when', () => {
   })
 
   it('should respect custom asymmetric matchers', () => {
-    const spy = vi.fn()
-
-    subject.when(spy).calledWith(expect.toBeFoo()).thenReturn(1000)
+    const spy = subject
+      .when(vi.fn())
+      .calledWith(expect.toBeFoo())
+      .thenReturn(1000)
 
     expect(spy('foo')).toEqual(1000)
   })
 
   it('should deeply check object arguments', () => {
-    const spy = vi.fn()
-
-    subject
-      .when(spy)
+    const spy = subject
+      .when(vi.fn())
       .calledWith({ foo: { bar: { baz: 0 } } })
       .thenReturn(100)
 
@@ -278,9 +252,9 @@ describe('vitest-when', () => {
   })
 
   it('should not trigger unhandled rejection warnings when rejection unused', () => {
-    const spy = vi.fn()
     const error = new Error('uh uhh')
-    subject.when(spy).calledWith('/api/foo').thenReject(error)
+    subject.when(vi.fn()).calledWith('/api/foo').thenReject(error)
+
     // intentionally do not call the spy
     expect(true).toBe(true)
   })


### PR DESCRIPTION
This PR steals a convenient part of td.js' API that I haven't stolen yet:

```ts
// before
const mock = vi.fn()
when(mock).calledWith(1, 2).thenReturn(3)

// after
const mock = when(vi.fn()).calledWith(1, 2).thenReturn(3)
```