### PR TITLE
chore: add default to exports field in package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "exports": {
     ".": {
       "types": "./dist/vitest-when.d.ts",
-      "import": "./dist/vitest-when.js"
+      "import": "./dist/vitest-when.js",
+			"default": "./dist/vitest-when.js"
     }
   },
   "types": "./dist/vitest-when.d.ts",


### PR DESCRIPTION
# TLDR
when tsconfig.json field `compilerOptions.moduleResolution = "bundler"`, i was getting `Unable to resolve path to module`

##  Before package json change
<img width="1320" height="344" alt="image" src="https://github.com/user-attachments/assets/a38864df-4b0b-46e0-abbc-6dc119c759ca" />

## After
<img width="1320" height="344" alt="image" src="https://github.com/user-attachments/assets/994ba03c-2f67-4f6d-8ed5-409e9bd92c7a" />

