### PR TITLE
refactor(types)!: revert #23 due to Vitest revert

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,5 +14,17 @@ export default defineConfig(
       'unicorn/no-array-reverse': 'off',
     },
   },
+  {
+    files: ['src/types.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+  {
+    files: ['test/typing.test-d.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-argument': 'off',
+    },
+  },
   globalIgnores(['**/coverage/**', '**/dist/**']),
 )

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /** Common type definitions. */
-import type { AsymmetricMatcher } from '@vitest/expect'
 import type { MockedClass, MockedFunction } from 'vitest'
 
 /** Any function. */
@@ -80,11 +78,6 @@ export type ConstructorImplementation<
 > =
   | (new (...args: ConstructorParameters<TFunc>) => InstanceType<TFunc>)
   | ((this: InstanceType<TFunc>, ...args: ConstructorParameters<TFunc>) => void)
-
-/** Accept a value or an AsymmetricMatcher in an arguments array */
-export type WithMatchers<T extends unknown[]> = {
-  [K in keyof T]: AsymmetricMatcher<unknown> | T[K]
-}
 
 /** A mocked function or constructor. */
 export type Mock<TFunc extends AnyMockable> = TFunc extends AnyConstructor

--- a/src/vitest-when.ts
+++ b/src/vitest-when.ts
@@ -10,7 +10,6 @@ import type {
   NormalizeMockable,
   ParametersOf,
   ReturnTypeOf,
-  WithMatchers,
 } from './types.ts'
 
 export { type Behavior, BehaviorType, type WhenOptions } from './behaviors.ts'
@@ -21,9 +20,7 @@ export interface StubWrapper<
   TFunc extends AnyMockable,
   TOptions extends WhenOptions | undefined,
 > {
-  calledWith<TArgs extends ArgumentsSpec<ParametersOf<TFunc>, TOptions>>(
-    ...args: WithMatchers<TArgs>
-  ): Stub<TFunc>
+  calledWith(...args: ArgumentsSpec<ParametersOf<TFunc>, TOptions>): Stub<TFunc>
 }
 
 export interface Stub<TFunc extends AnyMockable> {

--- a/test/typing.test-d.ts
+++ b/test/typing.test-d.ts
@@ -75,6 +75,14 @@ describe('vitest-when type signatures', () => {
     subject
       .when(multipleArgs, { ignoreExtraArgs: true })
       .calledWith(expect.any(Number), expect.any(String), expect.any(Boolean))
+
+    subject.when(multipleArgs, { ignoreExtraArgs: true }).calledWith(
+      // @ts-expect-error: too many arguments
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    )
   })
 
   it('returns mock type for then resolve', () => {

--- a/test/vitest-when.test.ts
+++ b/test/vitest-when.test.ts
@@ -281,7 +281,7 @@ describe('vitest-when', () => {
   })
 
   it.each([
-    { stubArgs: [] as unknown[], callArgs: [] as unknown[] },
+    { stubArgs: [], callArgs: [] },
     { stubArgs: [], callArgs: ['a'] },
     { stubArgs: [], callArgs: ['a', 'b'] },
     { stubArgs: ['a'], callArgs: ['a'] },
@@ -300,7 +300,7 @@ describe('vitest-when', () => {
   )
 
   it.each([
-    { stubArgs: ['a'] as unknown[], callArgs: ['b'] as unknown[] },
+    { stubArgs: ['a'], callArgs: ['b'] },
     { stubArgs: [undefined], callArgs: [] },
   ])(
     'does not match call $callArgs against stub $stubArgs with ignoreExtraArgs',


### PR DESCRIPTION
This PR reverts the types added by #23. These types were added in response to https://github.com/vitest-dev/vitest/pull/7016, which changed the return type of various asymmetric matchers from `any` to `AsymmetricMatcher`

That change was released in [vitest@3.2.0](https://github.com/vitest-dev/vitest/releases/tag/v3.2.0) and subsequently reverted in [vitest@3.2.3](https://github.com/vitest-dev/vitest/releases/tag/v3.2.3). It was not carried forward into `vitest@4`

Keeping the `WithMatchers` utility around complicates our types without any benefit I can see, so I'm removing them!