### PR TITLE
feat!: add Vitest v5 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,13 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['18', '20', '22', '24']
-        vitest-version: ['latest']
-        include:
-          - node-version: '24'
-            vitest-version: '2'
-          - node-version: '24'
-            vitest-version: '3'
+        node-version: ['22', '24']
+        vitest-version: ['2', '3', 'latest', 'beta']
 
     steps:
       - name: Checkout source
@@ -32,9 +27,16 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Override vitest version
+      - name: Override Vitest version
         if: matrix.vitest-version != 'latest'
-        run: pnpm add --no-lockfile -D vitest@${{ matrix.vitest-version }} @vitest/expect@${{ matrix.vitest-version }} @vitest/coverage-istanbul@${{ matrix.vitest-version }}
+        env:
+          version: ${{ matrix.vitest-version }}
+        run: |
+          pnpm add --no-lockfile -D \
+            vitest@${version} \
+            @vitest/expect@${version} \
+            @vitest/pretty-format@${version} \
+            @vitest/coverage-istanbul@${version}
 
       - name: Run tests
         run: pnpm coverage

--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
     "test": "vitest"
   },
   "prettier": "@mcous/prettier-config",
-  "dependencies": {
-    "pretty-format": "^30.3.0"
-  },
   "devDependencies": {
     "@mcous/eslint-config": "^0.9.0",
     "@mcous/prettier-config": "^0.4.0",
@@ -59,11 +56,15 @@
     "vitest": "^4.1.5"
   },
   "peerDependencies": {
-    "@vitest/expect": ">=0.31.0 <5",
-    "vitest": ">=0.31.0 <5"
+    "@vitest/expect": "*",
+    "@vitest/pretty-format": "*",
+    "vitest": ">=2.0.2 <6"
   },
   "peerDependenciesMeta": {
     "@vitest/expect": {
+      "optional": true
+    },
+    "@vitest/pretty-format": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      pretty-format:
-        specifier: ^30.3.0
-        version: 30.3.0
+      '@vitest/pretty-format':
+        specifier: '*'
+        version: 4.1.5
     devDependencies:
       '@mcous/eslint-config':
         specifier: ^0.9.0
@@ -367,10 +367,6 @@ packages:
     resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
     engines: {node: '>=8'}
 
-  '@jest/schemas@30.0.5':
-    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
 
@@ -459,36 +455,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -550,66 +552,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -640,9 +655,6 @@ packages:
     resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
-
-  '@sinclair/typebox@0.34.49':
-    resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -800,10 +812,6 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
-
-  ansi-styles@5.2.0:
-    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
-    engines: {node: '>=10'}
 
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
@@ -1250,19 +1258,12 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  pretty-format@30.3.0:
-    resolution: {integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
-
-  react-is@18.3.1:
-    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
@@ -1850,10 +1851,6 @@ snapshots:
 
   '@istanbuljs/schema@0.1.6': {}
 
-  '@jest/schemas@30.0.5':
-    dependencies:
-      '@sinclair/typebox': 0.34.49
-
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.4
@@ -2047,8 +2044,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
-
-  '@sinclair/typebox@0.34.49': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2254,8 +2249,6 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
-
-  ansi-styles@5.2.0: {}
 
   ansis@4.2.0: {}
 
@@ -2674,17 +2667,9 @@ snapshots:
 
   prettier@3.8.3: {}
 
-  pretty-format@30.3.0:
-    dependencies:
-      '@jest/schemas': 30.0.5
-      ansi-styles: 5.2.0
-      react-is: 18.3.1
-
   punycode@2.3.1: {}
 
   quansync@1.0.0: {}
-
-  react-is@18.3.1: {}
 
   regexp-tree@0.1.27: {}
 

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,7 +1,7 @@
 import {
   format as prettyFormat,
   plugins as prettyFormatPlugins,
-} from 'pretty-format'
+} from '@vitest/pretty-format'
 
 import { type Behavior, BehaviorType } from './behaviors.ts'
 import { getBehaviorStack } from './stubs.ts'

--- a/src/fallback-implementation.ts
+++ b/src/fallback-implementation.ts
@@ -1,8 +1,8 @@
-import type { AnyFunction, MockInstance } from './types.ts'
+import type { AnyFunction, AnyMockInstance } from './types.ts'
 
 /** Get the fallback implementation of a mock if no matching stub is found. */
 export const getFallbackImplementation = (
-  mock: MockInstance,
+  mock: AnyMockInstance,
 ): AnyFunction | undefined => {
   return (
     (mock.getMockImplementation() as AnyFunction | undefined) ??
@@ -25,7 +25,7 @@ interface TinyspyInternals {
  * which is stored on a Symbol key in the mock object.
  */
 const getTinyspyInternals = (
-  mock: MockInstance,
+  mock: AnyMockInstance,
 ): TinyspyInternals | undefined => {
   const maybeTinyspy = mock as unknown as Record<PropertyKey, unknown>
 

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -10,7 +10,6 @@ import type {
   AsFunction,
   Mock,
   MockInstance,
-  NormalizeMockable,
   ParametersOf,
 } from './types.ts'
 
@@ -75,13 +74,13 @@ export const configureMock = <TFunc extends AnyMockable>(
 
 export const validateMock = <TFunc extends AnyMockable>(
   maybeMock: TFunc | MockInstance<TFunc>,
-): MockInstance<NormalizeMockable<TFunc>> => {
+): MockInstance<TFunc> => {
   if (
     typeof maybeMock === 'function' &&
     'mockImplementation' in maybeMock &&
     typeof maybeMock.mockImplementation === 'function'
   ) {
-    return maybeMock as unknown as MockInstance<NormalizeMockable<TFunc>>
+    return maybeMock as unknown as MockInstance<TFunc>
   }
 
   throw new NotAMockFunctionError(maybeMock)
@@ -102,6 +101,6 @@ export const getBehaviorStack = <TFunc extends AnyMockable>(
 
 export const asMock = <TFunc extends AnyMockable>(
   mock: MockInstance<TFunc>,
-): Mock<NormalizeMockable<TFunc>> => {
-  return mock as unknown as Mock<NormalizeMockable<TFunc>>
+): Mock<TFunc> => {
+  return mock as unknown as Mock<TFunc>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 /** Common type definitions. */
-import type { MockedClass, MockedFunction } from 'vitest'
+import type { MockedClass, MockedFunction, MockInstance } from 'vitest'
 
 /** Any function. */
 export type AnyFunction = (...args: any[]) => any
@@ -7,37 +7,11 @@ export type AnyFunction = (...args: any[]) => any
 /** Any constructor. */
 export type AnyConstructor = new (...args: any[]) => any
 
-/** Any mockable interface */
+/** Any mockable interface. */
 export type AnyMockable = AnyFunction | AnyConstructor
 
-/**
- * Minimally typed version of Vitest's `MockInstance`.
- *
- * Ensures backwards compatibility with vitest@<2
- */
-export interface MockInstance<TFunc extends AnyMockable = AnyMockable> {
-  getMockName(): string
-  getMockImplementation(): AsFunction<TFunc> | undefined
-  mockImplementation(impl: AsFunction<TFunc>): this
-  mock: {
-    calls: ParametersOf<TFunc>[]
-  }
-}
-
-/**
- * Normalize an inferred mock.
- *
- * When inferring the function type from `MockInstance`, constructors
- * can create a union type instead of a single type due to the union
- * in `ConstructorImplementation`. This type collapses that union.
- *
- * Ensures backwards compatibility with vitest@<2, because this
- * inference issue only happens with a custom `MockInstance`.
- */
-export type NormalizeMockable<TFunc extends AnyMockable> =
-  ConstructorImplementation extends TFunc
-    ? Extract<TFunc, AnyConstructor>
-    : TFunc
+/** Any mock instance, either of a function or a constructor. */
+export type AnyMockInstance = MockInstance<AnyMockable>
 
 /** Extract parameters from either a function or constructor. */
 export type ParametersOf<TFunc extends AnyMockable> =
@@ -85,3 +59,5 @@ export type Mock<TFunc extends AnyMockable> = TFunc extends AnyConstructor
   : TFunc extends AnyFunction
     ? MockedFunction<TFunc>
     : never
+
+export type { MockInstance } from 'vitest'

--- a/src/vitest-when.ts
+++ b/src/vitest-when.ts
@@ -3,11 +3,11 @@ import { type DebugResult, getDebug } from './debug.ts'
 import { asMock, configureMock, validateMock } from './stubs.ts'
 import type {
   AnyMockable,
+  AnyMockInstance,
   ArgumentsSpec,
   AsFunction,
   Mock,
   MockInstance,
-  NormalizeMockable,
   ParametersOf,
   ReturnTypeOf,
 } from './types.ts'
@@ -37,7 +37,7 @@ export const when = <
 >(
   mock: TFunc | MockInstance<TFunc>,
   options?: TOptions,
-): StubWrapper<NormalizeMockable<TFunc>, TOptions> => {
+): StubWrapper<TFunc, TOptions> => {
   const validatedMock = validateMock(mock)
   const behaviorStack = configureMock(validatedMock)
   const result = asMock(validatedMock)
@@ -77,7 +77,7 @@ export interface DebugOptions {
 }
 
 export const debug = (
-  mock: AnyMockable | MockInstance,
+  mock: AnyMockable | AnyMockInstance,
   options: DebugOptions = {},
 ): DebugResult => {
   const log = options.log ?? true

--- a/test/debug.test.ts
+++ b/test/debug.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import * as subject from '../src/vitest-when.ts'
 
 const DEBUG_OPTIONS = { log: false }
-const VI_FN_NAME_MATCHER = /(?:vi\.fn\(\)|spy)/u
+const VI_FN_NAME_MATCHER = /^(?:vi\.fn\(\)|spy)$/u
 
 describe('vitest-when debug', () => {
   it('debugs a non-stubbed spy', () => {
@@ -178,6 +178,6 @@ describe('vitest-when debug', () => {
 
     const result = subject.debug(spy, DEBUG_OPTIONS)
 
-    expect(result.description).toMatch(/\(\["x.+, …\]\)/u)
+    expect(result.description).toMatch(/\(\["x.+, …(?:\(\d+\))?\]\)/u)
   })
 })

--- a/test/typing.test-d.ts
+++ b/test/typing.test-d.ts
@@ -139,9 +139,7 @@ describe('vitest-when type signatures', () => {
       .calledWith(1)
       .thenReturn({ simpleMethod: () => '' })
 
-    expectTypeOf(result).branded.toEqualTypeOf<
-      MockedClass<typeof SimpleClass>
-    >()
+    expectTypeOf(result).toEqualTypeOf<MockedClass<typeof SimpleClass>>()
   })
 
   it('should handle a generic function', () => {


### PR DESCRIPTION
BREAKING CHANGE: support for Vitest <2 has been dropped,
Node <22 is still supported, but has been dropped from CI.